### PR TITLE
Upgrade solace-services-info to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Include version 4.0.0 or later to use Spring Boot release 2.x
 
 ```
 // Solace Cloud
-compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.1.0")
+compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.1.1")
 ```
 
 ### Using it with Maven
@@ -95,7 +95,7 @@ compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.1.0")
 <dependency>
   <groupId>com.solace.cloud.cloudfoundry</groupId>
   <artifactId>solace-spring-cloud-connector</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
-			<version>0.4.0</version>
+			<version>0.4.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes transient Jackson dependency issues when Jackson 3.x is present in Maven repositories.